### PR TITLE
Fix "initializer element is not constant" error by adding #define

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -13,16 +13,16 @@
 #ifndef _GLOBAL_CONSTANTS
 #define _GLOBAL_CONSTANTS
 
-static const char * WINDOW_TITLE = "tetris-sdl-c";
+#define WINDOW_TITLE "tetris-sdl-c"
 
 // a block 'pixel' of a playing field is 15px by 15px in size
-static const short int BLOCK_SIZE = 20;
+#define BLOCK_SIZE 20
 
 // standard size of a tetris playing field
-static const short int PLAYFIELD_HEIGHT = 22;
-static const short int PLAYFIELD_WIDTH = 10;
+#define PLAYFIELD_HEIGHT 22
+#define PLAYFIELD_WIDTH 10
 
-static const int WINDOW_HEIGHT = PLAYFIELD_HEIGHT * ( BLOCK_SIZE + 1) + 1;
-static const int WINDOW_WIDTH = PLAYFIELD_WIDTH * ( BLOCK_SIZE + 1) + 1;
+#define WINDOW_HEIGHT PLAYFIELD_HEIGHT * (BLOCK_SIZE + 1) + 1
+#define WINDOW_WIDTH PLAYFIELD_WIDTH * (BLOCK_SIZE + 1) + 1
 
 #endif


### PR DESCRIPTION
There is such an error when using gcc on Arch Linux:

```
gcc -g `sdl2-config --cflags` -c src/init.c
In file included from src/init.h:1:0,
                 from src/init.c:1:
src/defs.h:25:34: error: initializer element is not constant
 static const int WINDOW_HEIGHT = PLAYFIELD_HEIGHT * ( BLOCK_SIZE + 1) + 1;
                                  ^~~~~~~~~~~~~~~~
src/defs.h:26:33: error: initializer element is not constant
 static const int WINDOW_WIDTH = PLAYFIELD_WIDTH * ( BLOCK_SIZE + 1) + 1;
                                 ^~~~~~~~~~~~~~~
In file included from src/init.h:3:0,
                 from src/init.c:1:
src/tetris.h:114:20: error: variably modified ‘playfield’ at file scope
 static Color_Block playfield[PLAYFIELD_HEIGHT * PLAYFIELD_WIDTH];
                    ^~~~~~~~~
make: *** [makefile:13: init.o] Error 1
```

Adding "#define" instead of "static const int" make compilation work fine.